### PR TITLE
Update guides-quickstart.md specifics for nanbield

### DIFF
--- a/versioned_docs/version-nanbield/guides-quickstart.md
+++ b/versioned_docs/version-nanbield/guides-quickstart.md
@@ -8,26 +8,26 @@ description: Getting start with meta-erlang.
 # Quickstart
 
 This quickstart guide uses the same steps stated at
-[Yocto Project Quick Build](https://docs.yoctoproject.org/brief-yoctoprojectqs/brief-yoctoprojectqs.html)
+[Yocto Project Quick Build](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html)
 with additional steps to get an erlang runtime up and running on the target
 device.
 
-Clone _meta-erlang_:
+Clone _meta-erlang_ and checkout branch _nanbield_:
 
 ```bash
-git clone https://github.com/meta-erlang/meta-erlang.git
+git clone --branch nanbield https://github.com/meta-erlang/meta-erlang.git
 ```
 
-Clone _poky_ and checkout branch _kirkstone_:
+Clone _poky_ and checkout branch _nanbield_:
 
 ```bash
-git clone --branch kirkstone git://git.yoctoproject.org/poky
+git clone --branch nanbield git://git.yoctoproject.org/poky
 ```
 
-Clone _meta-openembedded_ and checkout branch _kirkstone_:
+Clone _meta-openembedded_ and checkout branch _nanbield_:
 
 ```bash
-git clone --branch kirkstone https://github.com/openembedded/meta-openembedded.git
+git clone --branch nanbield https://github.com/openembedded/meta-openembedded.git
 ```
 
 Move to _poky_ directory:
@@ -49,7 +49,7 @@ bitbake-layers add-layer ../meta-openembedded/meta-oe
 bitbake-layers add-layer ../meta-erlang
 ```
 
-Add `erlang` package to `IMAGE_INSTAL` in _conf/local.conf_
+Add `erlang` package to `IMAGE_INSTALL` in _conf/local.conf_
 
 ```bash
 echo 'IMAGE_INSTALL:append = " erlang"' >> conf/local.conf
@@ -64,18 +64,21 @@ bitbake core-image-minimal
 Run the qemu:
 
 ```bash
-runqemu qemux86
+runqemu qemux86-64
 ```
 
 A new window will open. Login as _root_ and call _erl_:
 
 ```bash
 # erl
-Erlang/OTP 21 [erts-10.1] [source] [smp:1:1] [ds:1:1:10] [async-threads:1]
+Erlang/OTP 25 [erts-13.2.2.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]
 
-Eshell V10.1 (abort with ^G)
+Eshell V13.2.2.5  (abort with ^G)
 1> erlang:system_info(cpu_topology).
-[{processor,{logical,0}}]
+[{processor,[{core,{logical,0}},
+             {core,{logical,1}},
+             {core,{logical,2}},
+             {core,{logical,3}}]}]
 ```
 
 The other sections of this guide shows additional steps to create your own


### PR DESCRIPTION
This update fixes the following problems:

- The nanbield version of this doc was referencing kirkstone by mistake.
- This doc was recommending checking out master branch of meta-erlang even though <https://github.com/meta-erlang/meta-erlang/blob/master/README.md> recommends checking out matching branch to yocto (i.e. nanbield).
- Tried to run a machine qemux86 which no longer exists (now qemux86-64)
- Bad link to yoctoproject quickstart
- Old example output from `erl`



